### PR TITLE
Multiple Network Whitelisting

### DIFF
--- a/nordvpn/root/etc/cont-init.d/030-local-network.sh
+++ b/nordvpn/root/etc/cont-init.d/030-local-network.sh
@@ -11,6 +11,20 @@ if [ ! -z ${NETWORK} ]; then
     iptables -A OUTPUT --destination ${NETWORK} -j ACCEPT
 fi
 
+if [ ! -z ${NETWORKS} ]; then
+    echo "Bypass requests for multiple networks thru regular connection...."
+    gw=`ip route | awk '/default/ {print $3}'`
+
+    IFS=','
+    read -rasplitIFS<<< "$NETWORKS"
+
+    for net in "${splitIFS[@]}"; do
+        echo ${net}
+	ip route add to ${net} via ${gw} dev eth0
+        iptables -A OUTPUT --destination ${net} -j ACCEPT
+    done
+fi
+
 if [ ! -z ${NETWORK6} ]; then
     echo "Bypass requests for local ip6 network thru regular connection..."
     gw=`ip -6 route | awk '/default/ {print $3}'`
@@ -18,4 +32,18 @@ if [ ! -z ${NETWORK6} ]; then
     ip6tables -A OUTPUT --destination ${NETWORK6} -j ACCEPT 2> /dev/null
 fi
 
+if [ ! -z ${NETWORKS6} ]; then
+    echo "Bypass requests for multiple networks thru regular connection..."
+    gw=`ip route | awk '/default/ {print $3}'`
+
+    IFS=','
+    read -rasplitIFS<<< "$NETWORKS6"
+
+    for net in "${splitIFS[@]}"; do
+        ip -6 route add to ${net} via ${gw} dev eth0
+        ip6tables -A OUTPUT --destination ${net} -j ACCEPT 2> /dev/null
+    done
+fi
+
 exit 0
+


### PR DESCRIPTION
Updated the _/root/etc/cont-init.d/030-local-network.sh_ script to support multiple networks.  Implemented by adding a new `NETWORKS` and `NETWORKS6` env var that takes comma delimited CIDR blocks. Personally needed this so that I could allow traffic from my load balanced IP (192.168.1.0/24) as well as the Kubernetes pod IP range (10.3.0.0/24), Ultimately allows for interaction with a pod both internally and externally.