### PR TITLE
Updated privoxy settings to reduce chance of memory leaks

### DIFF
--- a/nordvpn-privoxy/root/etc/privoxy/config
+++ b/nordvpn-privoxy/root/etc/privoxy/config
@@ -21,13 +21,14 @@ accept-intercepted-requests 1
 allow-cgi-request-crunching 0
 split-large-forms 0
 keep-alive-timeout 10
-tolerate-pipelining 1
+tolerate-pipelining 0
 default-server-timeout 15
 socket-timeout 300
 max-client-connections 256
 #handle-as-empty-doc-returns-ok 1
 #enable-compression 1
 #compression-level 1
+connection-sharing 0
 
 #actionsfile match-all.action # Actions that are applied to all sites and maybe overruled later on.
 #actionsfile default.action   # Main actions file


### PR DESCRIPTION
There are two settings in privoxy that when left to their defaults, can lead to memory leaks in long-running containers.

This change: 

* Disables connection-sharing which can lead to increasing orphaned connections, especially with VPN connection resets

* Turns off pipelining, which is now obsolete and can lead to  requests getting stuck in the pipeline, holding memory